### PR TITLE
Do not use fail-fast strategy for molecule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ on:
               "ansible_version": "stable-2.11"
             }
           ]
+      fail_fast:
+        required: false
+        type: boolean
+        default: false
 env:
   COLORTERM: 'yes'
   TERM: 'xterm-256color'
@@ -179,7 +183,7 @@ jobs:
         python_version: ["3.11"]
         ansible_version: ["2.15", "2.16"]
         molecule_test: ${{ fromJSON(inputs.molecule_tests) }}
-      fail-fast: false
+      fail-fast: ${{ inputs.fail_fast }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,7 @@ jobs:
         python_version: ["3.11"]
         ansible_version: ["2.15", "2.16"]
         molecule_test: ${{ fromJSON(inputs.molecule_tests) }}
+      fail-fast: false
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
So that we won't get a bunch of cancelled jobs because of one failed download

https://github.com/ansible-middleware/jws/actions/runs/11607162879
