### PR TITLE
Remove obsolete changelogs/fragments/.gitignore sanity exclude

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Run sanity tests
         run: |
           python -V
-          ansible-test sanity -v --color --requirements --python ${{ matrix.python_version }} --exclude molecule/ --exclude docs/conf.py --exclude changelogs/fragments/.gitignore --skip-test symlinks
+          ansible-test sanity -v --color --requirements --python ${{ matrix.python_version }} --exclude molecule/ --exclude docs/conf.py --skip-test symlinks
         working-directory: ./ansible_collections/${{ inputs.fqcn }}
 
   molecule:

--- a/.github/workflows/cish.yml
+++ b/.github/workflows/cish.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Run sanity tests
         run: |
           python -V
-          ansible-test sanity -v --color --requirements --python ${{ matrix.python_version }} --exclude molecule/ --exclude docs/conf.py --exclude changelogs/fragments/.gitignore --skip-test symlinks
+          ansible-test sanity -v --color --requirements --python ${{ matrix.python_version }} --exclude molecule/ --exclude docs/conf.py --skip-test symlinks
         working-directory: ./ansible_collections/${{ inputs.fqcn }}
 
   molecule:


### PR DESCRIPTION
## Summary
- Drop `--exclude changelogs/fragments/.gitignore` from shared CI sanity commands.
- Collections (e.g. wildfly) no longer ship that file; ansible-test now fails with `Target pattern not matched` when the exclude path is missing.

## Test plan
- [ ] Re-run wildfly PR CI after merge (`@rootperm`)
- [ ] Confirm sanity jobs no longer fail on missing exclude path

Made with [Cursor](https://cursor.com)