### PR TITLE
Remove obsolete changelogs/fragments/.gitignore sanity exclude

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Run sanity tests
         run: |
           python -V
-          ansible-test sanity -v --color --requirements --python ${{ matrix.python_version }} --exclude molecule/ --exclude docs/conf.py --exclude changelogs/fragments/.gitignore --skip-test symlinks
+          ansible-test sanity -v --color --requirements --python ${{ matrix.python_version }} --exclude molecule/ --exclude docs/conf.py --skip-test symlinks
         working-directory: ./ansible_collections/${{ inputs.fqcn }}
 
   molecule:

--- a/.github/workflows/cish.yml
+++ b/.github/workflows/cish.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Run sanity tests
         run: |
           python -V
-          ansible-test sanity -v --color --requirements --python ${{ matrix.python_version }} --exclude molecule/ --exclude docs/conf.py --exclude changelogs/fragments/.gitignore --skip-test symlinks
+          ansible-test sanity -v --color --requirements --python ${{ matrix.python_version }} --exclude molecule/ --exclude docs/conf.py --skip-test symlinks
         working-directory: ./ansible_collections/${{ inputs.fqcn }}
 
   molecule:


### PR DESCRIPTION
- Drop --exclude changelogs/fragments/.gitignore from shared CI sanity commands.
- Collections (e.g. wildfly) no longer ship that file; ansible-test now fails with Target pattern not matched when the exclude path is missing.

[AMW-609](https://redhat.atlassian.net/browse/AMW-609)